### PR TITLE
value not repected when provided in display of timezone list

### DIFF
--- a/modules/plugin_timezone/__init__.py
+++ b/modules/plugin_timezone/__init__.py
@@ -94,19 +94,24 @@ TZDICT = dict((tzn[0], 1) for tzn in TZSETS)
 
 def tz_nice_detector_widget(field, value, **attributes):
     options = []
+    value_missing = True
     for tzn in TZSETS:
         #retrieve offset
         localized = datetime.datetime.now(pytz.timezone(tzn[0]))
-        options.append(
-            OPTION(tzn[1], _value=tzn[0],
-                   data=dict(localized=localized.strftime('%Y-%m-%d %H:%M'))
-                   )
-        )
-
+        if value == tzn[0]:
+            # This is the preselected value.
+            value_missing = False
+            options.append(
+                OPTION(tzn[1], _value=tzn[0], _selected="selected",
+                       data=dict(localized=localized.strftime('%Y-%m-%d %H:%M'))))
+        else:
+            options.append(
+                OPTION(tzn[1], _value=tzn[0],
+                       data=dict(localized=localized.strftime('%Y-%m-%d %H:%M'))))
 
     _id = '%s_%s' % (field._tablename, field.name)
     _name = field.name
-    if 'autodetect' in attributes and attributes.pop('autodetect') is True:
+    if value_missing and 'autodetect' in attributes and attributes.pop('autodetect') is True:
         current.response.files.append(URL('static', 'plugin_timezone/jstz.min.js'))
         script = """
 jQuery(document).ready(function () {


### PR DESCRIPTION
When 'value' is provided to the tz_nice_detector_widget, the value needs to be displayed, because it corresponds to the currently set value in the database.
Before this change, the content of 'value' was always disregarded, and the timezone that was shown as selected always corresponded to the currently autodetected one. 
After this change, if the 'value' field contains a valid timezone, the timezone shown corresponds to the one in the 'value' field, so that the widget behaves like any other normal web2py widget. 

This change corresponds, in a way, to having: 
db.table.field.default = autodetected time zone
rather than 
form.vars.field = autodetected time zone
