### PR TITLE
correction to sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ definition
 
 ```python
 import pytz
-user_timezone = auth.user.user_timezone_timezone or 'UTC'
+user_timezone = auth.user.user_timezone or 'UTC'
 
 db.define_table('sometable',
   Field('appointment', 'datetime', 


### PR DESCRIPTION
fixed sample code typo in line 103, from `auth.user.user_timezone_timezone` to `auth.user.user_timezone`